### PR TITLE
Fix build issues and flesh out bot skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+dist/
+.env

--- a/README.md
+++ b/README.md
@@ -1,1 +1,43 @@
-# Book-worms
+# Book-worms Bot
+
+This project is a Telegram bot for tracking daily reading tasks. It uses
+Express.js, Telegraf, TypeScript and Prisma with a PostgreSQL database.
+
+## Setup
+
+Install dependencies with:
+
+```bash
+npm install
+```
+
+Environment variables required:
+
+- `BOT_TOKEN` – Telegram bot token.
+- `DATABASE_URL` – PostgreSQL connection string.
+
+Generate the Prisma client after installing packages:
+
+```bash
+npx prisma generate
+```
+
+## Development
+
+Run the bot in development mode:
+
+```bash
+npm run dev
+```
+
+Build TypeScript sources:
+
+```bash
+npm run build
+```
+
+### Note about this environment
+
+The environment used for this repository does not allow network access,
+therefore `npm install` will fail here. Dependencies must be installed in an
+environment with internet access or using a prepared setup script.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "book-worms",
+  "version": "1.0.0",
+  "description": "",
+  "main": "dist/index.js",
+  "scripts": {
+    "build": "tsc",
+    "start": "node dist/index.js",
+    "dev": "ts-node-dev src/index.ts"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "dependencies": {
+    "@prisma/client": "^5.15.0",
+    "express": "^4.19.2",
+    "telegraf": "^4.12.3"
+  },
+  "devDependencies": {
+    "@types/express": "^4.17.21",
+    "@types/node": "^20.4.2",
+    "@types/telegraf": "^4.0.3",
+    "prisma": "^5.15.0",
+    "ts-node-dev": "^2.0.0",
+    "typescript": "^5.5.0"
+  }
+}

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,0 +1,31 @@
+// Example Prisma schema
+// This schema defines basic User and Task models to track task completion.
+
+generator client {
+  provider = "prisma-client-js"
+}
+
+datasource db {
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
+}
+
+model User {
+  id        Int      @id @default(autoincrement())
+  telegramId String   @unique
+  name      String
+  tasks     Task[]
+  createdAt DateTime @default(now())
+}
+
+model Task {
+  id        Int      @id @default(autoincrement())
+  userId    Int
+  date      DateTime
+  completed Boolean  @default(false)
+  penaltyPaid Boolean @default(false)
+
+  user User @relation(fields: [userId], references: [id])
+
+  @@unique([userId, date])
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,43 @@
+import express, { Request, Response } from 'express';
+import { Telegraf, Context } from 'telegraf';
+import { PrismaClient } from '@prisma/client';
+
+const prisma = new PrismaClient();
+
+const BOT_TOKEN = process.env.BOT_TOKEN || '';
+const bot = new Telegraf(BOT_TOKEN);
+
+bot.command('vazifa', async (ctx: Context) => {
+  const telegramId = ctx.from?.id.toString() || '';
+  const name = `${ctx.from?.first_name ?? ''} ${ctx.from?.last_name ?? ''}`.trim();
+
+  const user = await prisma.user.upsert({
+    where: { telegramId },
+    update: { name },
+    create: { telegramId, name }
+  });
+
+  const today = new Date();
+  const date = new Date(today.getFullYear(), today.getMonth(), today.getDate());
+
+  await prisma.task.upsert({
+    where: { userId_date: { userId: user.id, date } },
+    update: { completed: true },
+    create: { userId: user.id, date, completed: true }
+  });
+
+  await ctx.reply('Vazifa qabul qilindi');
+});
+
+const app = express();
+app.use(express.json());
+
+app.post('/webhook', (req: Request, res: Response) => {
+  bot.handleUpdate(req.body as any);
+  res.sendStatus(200);
+});
+
+const port = process.env.PORT ? parseInt(process.env.PORT) : 3000;
+app.listen(port, () => {
+  console.log(`Server running on port ${port}`);
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "target": "ES2019",
+    "module": "commonjs",
+    "rootDir": "src",
+    "outDir": "dist",
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true
+  }
+}


### PR DESCRIPTION
## Summary
- add missing dependencies and devDependencies
- create Prisma unique constraint for tasks
- implement basic Telegram bot logic with Prisma
- document installation and development steps
- ignore build and environment files

## Testing
- `npm run build` *(fails: cannot find module 'express' etc. because dependencies were not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686c3ecc55408323b4ce36243fee67d7